### PR TITLE
fix: fix path traversal vulnerability and upgrade security dependencies

### DIFF
--- a/templates/golang/{{cookiecutter.project_name}}/cmd/gen_definition_yaml.go
+++ b/templates/golang/{{cookiecutter.project_name}}/cmd/gen_definition_yaml.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/TencentBlueKing/bk-apigateway-sdks/gin_contrib/gen"
 	log "github.com/TencentBlueKing/blueapps-go/pkg/logging"
@@ -31,6 +32,24 @@ func NewGenDefinitionYamlCmd() *cobra.Command {
 			}
 			apiConfig := config.GetApiConfig(cfg)
 			engine := router.New(log.GetLogger("gin"))
+
+			// 校验 docsDir，防止路径遍历导致任意文件写入
+			absDocsDir, err := filepath.Abs(docsDir)
+			if err != nil {
+				log.Fatalf("failed to resolve docs dir: %s", err)
+			}
+			cwd, err := os.Getwd()
+			if err != nil {
+				log.Fatalf("failed to get current working directory: %s", err)
+			}
+			rel, err := filepath.Rel(cwd, absDocsDir)
+			if err != nil {
+				log.Fatalf("failed to validate docs dir: %s", err)
+			}
+			if strings.HasPrefix(rel, "..") {
+				log.Fatalf("invalid docs dir %q: path traversal detected", docsDir)
+			}
+
 			docPath := docsDir + "/swagger.json"
 			yaml := gen.GenDefinitionYaml(apiConfig, docPath, engine)
 			log.Infof(ctx, "gen definition yaml success:\n %s", yaml)

--- a/templates/golang/{{cookiecutter.project_name}}/go.mod
+++ b/templates/golang/{{cookiecutter.project_name}}/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/context v1.1.2 // indirect
-	github.com/gorilla/csrf v1.7.2 // indirect
+	github.com/gorilla/csrf v1.7.3 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gorilla/sessions v1.4.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
@@ -120,12 +120,12 @@ require (
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
 	golang.org/x/arch v0.20.0 // indirect
-	golang.org/x/crypto v0.41.0 // indirect
+	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/mod v0.27.0 // indirect
-	golang.org/x/net v0.43.0 // indirect
+	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
-	golang.org/x/sys v0.35.0 // indirect
-	golang.org/x/text v0.28.0 // indirect
+	golang.org/x/sys v0.38.0 // indirect
+	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/tools v0.36.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250811230008-5f3141c8851a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250811230008-5f3141c8851a // indirect

--- a/templates/golang/{{cookiecutter.project_name}}/go.sum
+++ b/templates/golang/{{cookiecutter.project_name}}/go.sum
@@ -94,7 +94,8 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/context v1.1.2/go.mod h1:KDPwT9i/MeWHiLl90fuTgrt4/wPcv75vFAZLaOOcbxM=
-github.com/gorilla/csrf v1.7.2/go.mod h1:F1Fj3KG23WYHE6gozCmBAezKookxbIvUJT+121wTuLk=
+github.com/gorilla/csrf v1.7.3 h1:BHWt6FTLZAb2HtWT5KDBf6qgpZzvtbp9QWDRKZMXJC0=
+github.com/gorilla/csrf v1.7.3/go.mod h1:F1Fj3KG23WYHE6gozCmBAezKookxbIvUJT+121wTuLk=
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/sessions v1.2.2/go.mod h1:ePLdVu+jbEgHH+KWw8I1z2wqd0BAdAQh/8LRvBeoNcQ=
 github.com/gorilla/sessions v1.4.0/go.mod h1:FLWm50oby91+hl7p/wRxDth9bWSuk0qVL2emc7lT5ik=


### PR DESCRIPTION
### Changes

1. **Fix path traversal vulnerability (arbitrary file write)**
   - File: `cmd/gen_definition_yaml.go`
   - Issue: The `docsDir` parameter comes directly from CLI arguments or environment variables and is concatenated into file write paths without validation, leading to a path traversal risk.
   - Fix: Add path validation to ensure the resolved absolute path of `docsDir` stays within the current working directory, preventing malicious paths like `../../etc`.

2. **Upgrade security-related dependencies**
   - `golang.org/x/crypto` `v0.41.0` → `v0.45.0` (fixes CVE-2025-47914)
   - `golang.org/x/net` `v0.43.0` → `v0.47.0` (security fixes)
   - `github.com/gorilla/csrf` `v1.7.2` → `v1.7.3` (fixes CVE-2025-24358)

### Compatibility

- `golang.org/x/crypto`, `golang.org/x/net`, and `github.com/gorilla/csrf` are all indirect dependencies (`// indirect`). The project code does not import or use their APIs directly, so the upgrades have no impact on business logic.
