### PR TITLE
feat: upgrade apigw-manager to 4.2.4 and bk-apigateway-sdks to 1.1.4 with MCP Server new fields

### DIFF
--- a/docs/golang.md
+++ b/docs/golang.md
@@ -161,20 +161,27 @@ func GetStageConfig(cfg *SvcConfig) *model.StageConfig {
 	if stageConfig.EnableMcpServers {
 		stageMcpServers := []*model.McpServer{
 			{
-				Name:        "mcp-server",
+				Name:  "mcp-server",
+				Title: "MCP 服务",
 				Description: "mcp-server",
-				// 中文名
-				Title: "示例 mcpserver"
-				// 是否公开
+				// 是否公开，默认不公开
 				IsPublic: true,
-				// 是否启用：0-未启用，1-启用
-				Status: 1,
-				// 协议类型：sse/streamable_http; 推荐使用 streamable_http 更稳定
+				// 协议类型：sse（默认）、streamable_http
 				ProtocolType: model.MCPServerProtocolStreamableHTTP,
-				// mcp server 绑定的资源列表
-				Tools: []string{"create_user"},
+				// 是否启用：0-未启用，1-启用（必选字段）
+				Status: 1,
+				// mcp server 绑定的资源名称列表
+				ResourceNames: []string{"create_user"},
+				// 工具名称列表，默认等于 ResourceNames；如需重命名可设置此字段，长度必须与 ResourceNames 一致且不能重复
+				// ToolNames: []string{"create_user"},
 				// 主动授权
 				TargetAppCodes: []string{"app1"},
+				// 是否开启 OAuth2 公开客户端模式，开启后将对 bk_app_code=public 的应用授权，默认不开启
+				// Oauth2PublicClientEnabled: false,
+				// 是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息，默认不开启
+				// RawResponseEnabled: false,
+				// MCP Server 分类名称列表，不传则不更新分类
+				// CategoryNames: []string{"Official"},
 			},
 		}
 		stageConfig.McpServerConfigs = stageMcpServers

--- a/docs/golang.md
+++ b/docs/golang.md
@@ -242,6 +242,47 @@ func GetReleaseConfig(cfg *SvcConfig) model.ReleaseConfig {
 	)
 ```
 
+## MCP Server 配置说明
+
+API 声明时通过 `basicConfig.WithMcpEnable(true)` 开启 MCP 功能。
+
+MCP Server 配置字段说明：
+
+| 参数名称 | 参数类型 | 必选 | 描述 |
+|---------|---------|------|------|
+| `name` | string | 是 | MCP Server 名字，系统会自动转换为 `{gateway_name}-{stage_name}-{name}` |
+| `title` | string | 否 | MCP Server 中文名/显示名称 |
+| `description` | string | 是 | MCP Server 描述 |
+| `labels` | array[string] | 否 | MCP Server 标签 |
+| `resource_names` | array[string] | 是 | MCP Server 关联的资源列表，对应 resources.yaml 中定义的资源名称 |
+| `tool_names` | array[string] | 否 | MCP Server 工具名称列表，默认等于 resource_names。如需对资源进行重命名可设置此字段，长度必须与 resource_names 一致，且不能重复 |
+| `is_public` | bool | 否 | 是否公开，默认不公开 |
+| `status` | integer | 是 | 状态：1 表示启用，0 表示关闭 |
+| `protocol_type` | string | 否 | MCP 协议类型：`sse`（默认）、`streamable_http` |
+| `target_app_codes` | array[string] | 否 | 主动授权的应用列表 |
+| `oauth2_public_client_enabled` | bool | 否 | 是否开启 OAuth2 公开客户端模式，开启后将对 `bk_app_code=public` 的应用进行授权，默认不开启 |
+| `raw_response_enabled` | bool | 否 | 是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息，默认不开启 |
+| `category_names` | array[string] | 否 | MCP Server 分类名称列表，不传则不更新分类 |
+
+支持的分类（category_names）：
+
+| 分类标识 | 描述 |
+|---------|------|
+| `Uncategorized` | 未分类 |
+| `Official` | 官方资源 |
+| `Featured` | 精选推荐 |
+| `Monitoring` | 监控告警 |
+| `ConfigManagement` | 配置管理 |
+| `DevOps` | 持续交付 |
+| `Emergency` | 故障管理 |
+| `Database` | 数据服务 |
+| `Automation` | 运维自动化 |
+| `Observability` | 可观测性 |
+| `Security` | 安全合规 |
+| `ResourceOptimize` | 资源优化 |
+| `ChaosEngineering` | 混沌工程 |
+| `Network` | 网络管理 |
+
 配置完之后，可以本地生成 definition.yaml 和 resources.yaml 进行测试
 
 ```bash

--- a/docs/python.md
+++ b/docs/python.md
@@ -366,6 +366,43 @@ class DemoRetrieveApi(generics.RetrieveAPIView):
 ```
 配置：
 
+MCP Server 配置字段说明：
+
+| 参数名称 | 参数类型 | 必选 | 描述 |
+|---------|---------|------|------|
+| `name` | string | 是 | MCP Server 名字，系统会自动转换为 `{gateway_name}-{stage_name}-{name}` |
+| `title` | string | 否 | MCP Server 中文名/显示名称 |
+| `description` | string | 是 | MCP Server 描述 |
+| `labels` | array[string] | 否 | MCP Server 标签 |
+| `tools` | array[string] | 是 | MCP Server 关联的资源列表，对应 resources.yaml 中定义的资源名称 |
+| `tool_names` | array[string] | 否 | MCP Server 工具名称列表，默认等于 tools(resource_names)。如需对资源进行重命名可设置此字段，长度必须与 tools 一致，且不能重复 |
+| `is_public` | bool | 否 | 是否公开，默认不公开 |
+| `status` | integer | 是 | 状态：1 表示启用，0 表示关闭 |
+| `protocol_type` | string | 否 | MCP 协议类型：`sse`（默认）、`streamable_http` |
+| `target_app_codes` | array[string] | 否 | 主动授权的应用列表 |
+| `oauth2_public_client_enabled` | bool | 否 | 是否开启 OAuth2 公开客户端模式，开启后将对 `bk_app_code=public` 的应用进行授权，默认不开启 |
+| `raw_response_enabled` | bool | 否 | 是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息，默认不开启 |
+| `category_names` | array[string] | 否 | MCP Server 分类名称列表，不传则不更新分类 |
+
+支持的分类（category_names）：
+
+| 分类标识 | 描述 |
+|---------|------|
+| `Uncategorized` | 未分类 |
+| `Official` | 官方资源 |
+| `Featured` | 精选推荐 |
+| `Monitoring` | 监控告警 |
+| `ConfigManagement` | 配置管理 |
+| `DevOps` | 持续交付 |
+| `Emergency` | 故障管理 |
+| `Database` | 数据服务 |
+| `Automation` | 运维自动化 |
+| `Observability` | 可观测性 |
+| `Security` | 安全合规 |
+| `ResourceOptimize` | 资源优化 |
+| `ChaosEngineering` | 混沌工程 |
+| `Network` | 网络管理 |
+
 ```python
 # 是否开启同步 MCP Server
 BK_APIGW_STAGE_ENABLE_MCP_SERVERS = False
@@ -374,43 +411,59 @@ stage_mcp_servers = {
         {
             "name": "mcp_server1",
             # 中文名
-            "title": "示例 mcpserver1"
+            "title": "MCP 服务1",
             "description": "mcp_server1",
             # 主动授权 app_code
             "target_app_codes": [APP_CODE],
             "labels": ["demo1"],
-            # 是否启用：1-启用，0-停止
+            # 是否启用：1-启用，0-停止（必选字段）
             "status": 1,
-            # 协议类型：sse/streamable_http; 推荐使用 streamable_http 更稳定
+            # 协议类型：sse（默认）、streamable_http
             "protocol_type": "streamable_http",
-            # 是否公开
+            # 是否公开，默认不公开
             "is_public": True,
             # 添加的资源列表(如果不指定则会将符合规范的都加入)
-            "tools": []
+            "tools": [],
+            # 工具名称列表，默认等于 tools(resource_names)；如需重命名可设置此字段，长度必须与 tools 一致且不能重复
+            # "tool_names": [],
+            # 是否开启 OAuth2 公开客户端模式，开启后将对 bk_app_code=public 的应用授权，默认不开启
+            # "oauth2_public_client_enabled": False,
+            # 是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息，默认不开启
+            # "raw_response_enabled": False,
+            # MCP Server 分类名称列表，不传则不更新分类
+            # "category_names": [],
         }
     ],
     "prod": [
         {
             "name": "mcp_server1",
-            "title": "示例 mcpserver1"
+            "title": "mcp_server1",
             "description": "mcp_server1",
             "target_app_codes": [APP_CODE],
             "labels": ["demo1"],
             "status": 0,
             "protocol_type": "streamable_http",
             "is_public": False,
-            "tools": []
+            "tools": [],
+            # "tool_names": [],
+            # "oauth2_public_client_enabled": False,
+            # "raw_response_enabled": False,
+            # "category_names": [],
         },
         {
             "name": "mcp_server2",
-            "title": "示例 mcpserver2"
+            "title": "mcp_server2",
             "description": "mcp_server2",
             "target_app_codes": [APP_CODE],
             "labels": ["demo2"],
             "status": 1,
             "protocol_type": "streamable_http",
             "is_public": True,
-            "tools": ["demo2"]
+            "tools": ["demo2"],
+            # "tool_names": ["demo2"],
+            # "oauth2_public_client_enabled": False,
+            # "raw_response_enabled": False,
+            # "category_names": ["Official"],
         }
     ]
 }

--- a/templates/golang/{{cookiecutter.project_name}}/go.mod
+++ b/templates/golang/{{cookiecutter.project_name}}/go.mod
@@ -9,7 +9,7 @@ toolchain go1.24.2
 replace github.com/go-sql-driver/mysql => github.com/go-sql-driver/mysql v1.7.1
 
 require (
-	github.com/TencentBlueKing/bk-apigateway-sdks v1.1.3
+	github.com/TencentBlueKing/bk-apigateway-sdks v1.1.4
 	github.com/TencentBlueKing/blueapps-go v1.6.2
 	github.com/gin-gonic/gin v1.10.1
 	github.com/pkg/errors v0.9.1

--- a/templates/golang/{{cookiecutter.project_name}}/pkg/config/gateway.go
+++ b/templates/golang/{{cookiecutter.project_name}}/pkg/config/gateway.go
@@ -115,16 +115,27 @@ func GetStageConfig(cfg *SvcConfig) *model.StageConfig {
 	if stageConfig.EnableMcpServers {
 		stageMcpServers := []*model.McpServer{
 			{
-				Name:        "mcp-server",
+				Name:  "mcp-server",
+				Title: "MCP 服务",
 				Description: "mcp-server",
-				// 是否公开
+				// 是否公开，默认不公开
 				IsPublic: true,
-				// 是否启用：0-未启用，1-启用
+				// 协议类型：sse（默认）、streamable_http
+				ProtocolType: model.MCPServerProtocolStreamableHTTP,
+				// 是否启用：0-未启用，1-启用（必选字段）
 				Status: 1,
-				// mcp server 绑定的资源列表
-				Tools: []string{},
+				// mcp server 绑定的资源名称列表
+				ResourceNames: []string{},
+				// 工具名称列表，默认等于 ResourceNames；如需重命名可设置此字段，长度必须与 ResourceNames 一致且不能重复
+				// ToolNames: []string{},
 				// 主动授权
 				TargetAppCodes: []string{"app1"},
+				// 是否开启 OAuth2 公开客户端模式，开启后将对 bk_app_code=public 的应用授权，默认不开启
+				// Oauth2PublicClientEnabled: false,
+				// 是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息，默认不开启
+				// RawResponseEnabled: false,
+				// MCP Server 分类名称列表，不传则不更新分类
+				// CategoryNames: []string{"Official"},
 			},
 		}
 		stageConfig.McpServerConfigs = stageMcpServers

--- a/templates/python/{{cookiecutter.project_name}}/config/settings.py
+++ b/templates/python/{{cookiecutter.project_name}}/config/settings.py
@@ -356,14 +356,22 @@ stage_mcp_servers = {
             # 主动授权 app_code
             "target_app_codes": [APP_CODE],
             "labels": ["demo1"],
-            # 是否启用：1-启用，0-停止
+            # 是否启用：1-启用，0-停止（必选字段）
             "status": 1,
-            # 是否公开
+            # 是否公开，默认不公开
             "is_public": True,
-            # 协议类型：streamable_http/sse
+            # 协议类型：sse（默认）、streamable_http
             "protocol_type": "streamable_http",
             # 添加的资源列表(如果不指定则会将符合规范的都加入)
-            "tools": []
+            "tools": [],
+            # 工具名称列表，默认等于 tools(resource_names)；如需重命名可设置此字段，长度必须与 tools 一致且不能重复
+            # "tool_names": [],
+            # 是否开启 OAuth2 公开客户端模式，开启后将对 bk_app_code=public 的应用授权，默认不开启
+            # "oauth2_public_client_enabled": False,
+            # 是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息，默认不开启
+            # "raw_response_enabled": False,
+            # MCP Server 分类名称列表，不传则不更新分类
+            # "category_names": [],
         }
     ],
     "prod": [
@@ -376,7 +384,11 @@ stage_mcp_servers = {
             "status": 0,
             "is_public": False,
             "protocol_type": "streamable_http",
-            "tools": []
+            "tools": [],
+            # "tool_names": [],
+            # "oauth2_public_client_enabled": False,
+            # "raw_response_enabled": False,
+            # "category_names": [],
         },
         {
             "name": "mcp_server2",
@@ -387,7 +399,11 @@ stage_mcp_servers = {
             "status": 1,
             "is_public": True,
             "protocol_type": "streamable_http",
-            "tools": ["demo2"]
+            "tools": ["demo2"],
+            # "tool_names": ["demo2"],
+            # "oauth2_public_client_enabled": False,
+            # "raw_response_enabled": False,
+            # "category_names": ["Official"],
         }
     ]
 }

--- a/templates/python/{{cookiecutter.project_name}}/requirements.txt
+++ b/templates/python/{{cookiecutter.project_name}}/requirements.txt
@@ -4,7 +4,7 @@ Django==3.2.25
 django-prometheus==2.3.1
 django-environ==0.12.0
 gunicorn==23.0.0
-apigw-manager[drf]==4.2.3
+apigw-manager[drf]==4.2.4
 python-json-logger==3.2.1
 concurrent-log-handler==0.9.25
 pymysql==1.1.1


### PR DESCRIPTION
## Summary

- Upgrade Python SDK `apigw-manager[drf]` from 4.2.3 to 4.2.4
- Upgrade Go SDK `bk-apigateway-sdks` from v1.1.3 to v1.1.4
- Add new MCP Server fields support: `tool_names`, `oauth2_public_client_enabled`, `raw_response_enabled`, `category_names`
- Rename Go SDK `Tools` field to `ResourceNames` for consistency
- Update `docs/python.md` with MCP Server field descriptions and category_names reference table
- Update `docs/golang.md` with new MCP Server configuration example

## Changes

### Python Template
- `requirements.txt`: bump `apigw-manager[drf]` 4.2.3 → 4.2.4
- `config/settings.py`: add new MCP Server fields with comments

### Go Template
- `go.mod`: bump `bk-apigateway-sdks` v1.1.3 → v1.1.4
- `pkg/config/gateway.go`: rename `Tools` → `ResourceNames`, add new fields

### Documentation
- `docs/python.md`: add MCP Server field description table and supported category_names table
- `docs/golang.md`: sync MCP Server configuration example with new fields

## Related PRs
- Python SDK: https://github.com/TencentBlueKing/bkpaas-python-sdk/commit/92d05e9f415e104fe0e31a3f0386cf7bbe97f676
- Go SDK: https://github.com/TencentBlueKing/bk-apigateway-sdks/pull/27


Made with [Cursor](https://cursor.com)